### PR TITLE
hotfix/SDT-8_fragment-lifecycle

### DIFF
--- a/app/src/main/java/sdt/tkm/at/steeldarttrainer/training/HighscoreTrainingsFragment.kt
+++ b/app/src/main/java/sdt/tkm/at/steeldarttrainer/training/HighscoreTrainingsFragment.kt
@@ -5,7 +5,6 @@ import android.app.Fragment
 import android.os.Bundle
 import android.support.v7.app.AlertDialog
 import android.view.LayoutInflater
-import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
 import android.widget.AdapterView
@@ -318,49 +317,6 @@ class HighscoreTrainingsFragment : Fragment() {
             }
         }
     }
-
-    /**
-    override fun onBackPressed() {
-
-    if (!dialogShown) {
-    dialogShown = true
-    val inflater = activity.layoutInflater
-    val dialogHintBuilder = AlertDialog.Builder(
-    activity)
-    val finishDialogView = inflater.inflate(R.layout.multiple_button_dialog, null)
-
-    val dialogText = finishDialogView.findViewById<TextView>(R.id.dialogText)
-    dialogText.text = this.getString(R.string.dialog_finish_training_text)
-    val exitButton = finishDialogView.findViewById<Button>(R.id.newGameButton)
-    exitButton.text = this.getString(R.string.dialog_finish_training_finish)
-    val closeButton = finishDialogView.findViewById<Button>(R.id.closeButton)
-    closeButton.text = this.getString(R.string.dialog_finish_training_close)
-
-    dialogHintBuilder.setView(finishDialogView)
-    val finishDialog = dialogHintBuilder.create()
-
-    exitButton.setOnClickListener {
-    finishDialog.dismiss()
-    dialogShown = false
-    LogEventsHelper(activity).logButtonTap("hs_finish_dialog_close")
-    //super.onBackPressed()
-    }
-
-    closeButton.setOnClickListener {
-    LogEventsHelper(this).logButtonTap("hs_finish_dialog_continue")
-    finishDialog.dismiss()
-    dialogShown = false
-    }
-
-    finishDialog.setCancelable(false)
-    finishDialog.setCanceledOnTouchOutside(false)
-    finishDialog.show()
-    return
-    }
-
-    super.onBackPressed()
-    }
-     */
 
     private fun defaultDarts() {
         firstDart.text = "-"

--- a/app/src/main/java/sdt/tkm/at/steeldarttrainer/training/TrainingsOverViewFragment.kt
+++ b/app/src/main/java/sdt/tkm/at/steeldarttrainer/training/TrainingsOverViewFragment.kt
@@ -1,7 +1,6 @@
 package sdt.tkm.at.steeldarttrainer.training
 
 import android.app.Fragment
-import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -127,7 +126,7 @@ class TrainingsOverViewFragment : Fragment() {
 
     private fun replaceFragment(fragment: Fragment) {
         val transaction = fragmentManager.beginTransaction()
-        transaction.add(R.id.content_frame, fragment)
+        transaction.replace(R.id.content_frame, fragment, "Detail_Training")
         transaction.addToBackStack(null)
         transaction.commit()
         oververviewActivity.showUpButton(true)

--- a/app/src/main/java/sdt/tkm/at/steeldarttrainer/training/XOITrainingsFragment.kt
+++ b/app/src/main/java/sdt/tkm/at/steeldarttrainer/training/XOITrainingsFragment.kt
@@ -289,43 +289,6 @@ class XOITrainingsFragment : Fragment() {
         }
     }
 
-    /**
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
-    when (item.getItemId()) {
-    android.R.id.home -> {
-    if (!oververviewActivity.isDialogShown) {
-    oververviewActivity.isDialogShown = true
-    val chooserDialog = ChooserDialogFragment.Companion.newChooserDialog(
-    getString(R.string.general_hint),
-    getString(R.string.dialog_finish_training_text),
-    getString(R.string.dialog_finish_training_finish),
-    getString(R.string.dialog_finish_training_close)
-    )
-
-    chooserDialog.listener = object : ChooserDialogFragment.ChooserDialogListener {
-    override fun positivButtonClicked() {
-    chooserDialog.dismiss()
-    oververviewActivity.isDialogShown = false
-    LogEventsHelper(oververviewActivity).logButtonTap("xoi_finish_dialog_close")
-    activity.onBackPressed()
-    }
-
-    override fun negativeButtonClicked() {
-    chooserDialog.dismiss()
-    LogEventsHelper(oververviewActivity).logButtonTap("xoi_finish_dialog_continue")
-    oververviewActivity.isDialogShown = false
-    }
-
-    }
-    return true
-    }
-
-    return false
-    }
-    else -> return super.onOptionsItemSelected(item)
-    }
-    }
-     */
     private fun defaultDarts() {
         firstDart.text = "-"
         secondDart.text = "-"

--- a/app/src/main/java/sdt/tkm/at/steeldarttrainer/training/XXTrainingsFragment.kt
+++ b/app/src/main/java/sdt/tkm/at/steeldarttrainer/training/XXTrainingsFragment.kt
@@ -3,7 +3,6 @@ package sdt.tkm.at.steeldarttrainer.training
 import android.app.Fragment
 import android.os.Bundle
 import android.support.v7.app.AlertDialog
-import android.support.v7.app.AppCompatActivity
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -13,13 +12,11 @@ import com.google.android.gms.ads.AdListener
 import com.google.android.gms.ads.AdRequest
 import com.google.android.gms.ads.AdView
 import com.google.android.gms.ads.InterstitialAd
-import com.shawnlin.numberpicker.NumberPicker
 import sdt.tkm.at.steeldarttrainer.R
 import sdt.tkm.at.steeldarttrainer.base.DataHolder
 import sdt.tkm.at.steeldarttrainer.base.LogEventsHelper
 import sdt.tkm.at.steeldarttrainer.base.OverviewActivity
 import sdt.tkm.at.steeldarttrainer.base.animateIntegerValue
-import sdt.tkm.at.steeldarttrainer.base.animateValue
 import sdt.tkm.at.steeldarttrainer.dialog.PickerDialogFragment
 import sdt.tkm.at.steeldarttrainer.models.XXTraining
 
@@ -218,7 +215,7 @@ class XXTrainingsFragment() : Fragment() {
         val adRequest = AdRequest.Builder().build()
         bannerAdView.loadAd(adRequest)
 
-        bannerAdView.adListener = object: AdListener() {
+        bannerAdView.adListener = object : AdListener() {
             override fun onAdLoaded() {
                 if (oververviewActivity != null) {
                     LogEventsHelper(oververviewActivity).logBannerLoaded(className)
@@ -250,7 +247,7 @@ class XXTrainingsFragment() : Fragment() {
         intersitalAd = InterstitialAd(oververviewActivity)
         intersitalAd.adUnitId = getString(R.string.interistal_id)
         intersitalAd.loadAd(AdRequest.Builder().build())
-        intersitalAd.adListener = object: AdListener() {
+        intersitalAd.adListener = object : AdListener() {
             override fun onAdLoaded() {
                 LogEventsHelper(oververviewActivity).logIntersitalLoaded(className)
             }
@@ -282,47 +279,6 @@ class XXTrainingsFragment() : Fragment() {
             intersitalAd.show()
         }
     }
-
-    /** override fun onBackPressed() {
-
-        if (!dialogShown) {
-            dialogShown = true
-            val inflater = oververviewActivity.layoutInflater
-            val dialogHintBuilder = AlertDialog.Builder(
-                this)
-            val finishDialogView = inflater.inflate(R.layout.multiple_button_dialog, null)
-
-            val dialogText = finishDialogView.findViewById<TextView>(R.id.dialogText)
-            dialogText.text = this.getString(R.string.dialog_finish_training_text)
-            val exitButton = finishDialogView.findViewById<Button>(R.id.newGameButton)
-            exitButton.text = this.getString(R.string.dialog_finish_training_finish)
-            val closeButton = finishDialogView.findViewById<Button>(R.id.closeButton)
-            closeButton.text = this.getString(R.string.dialog_finish_training_close)
-
-            dialogHintBuilder.setView(finishDialogView)
-            val finishDialog = dialogHintBuilder.create()
-
-            exitButton.setOnClickListener {
-                finishDialog.dismiss()
-                dialogShown = false
-                LogEventsHelper(oververviewActivity).logButtonTap("xx_finish_dialog_close")
-                super.onBackPressed()
-            }
-
-            closeButton.setOnClickListener {
-                finishDialog.dismiss()
-                LogEventsHelper(oververviewActivity).logButtonTap("xx_finish_dialog_continue")
-                dialogShown = false
-            }
-
-            finishDialog.setCancelable(false)
-            finishDialog.setCanceledOnTouchOutside(false)
-            finishDialog.show()
-            return
-        }
-
-        super.onBackPressed()
-    } */
 
     private fun newLeg() {
 


### PR DESCRIPTION
- fixed issue in any trainings fragment, when clicking multiple times on a "non-view element" another trainings fragment will be opened
- implemented check, which fragment called backPress in OverviewActivity, handling each case different